### PR TITLE
"self" link should appear in "links", not "relationships"

### DIFF
--- a/cartographer/serializers/jsonapi_serializer.py
+++ b/cartographer/serializers/jsonapi_serializer.py
@@ -103,13 +103,10 @@ class JSONAPISerializer(object):
         ]))
 
     def resource_links_json(self, version):
-        links_json = {
+        return {
             link_name: resource.as_link_json(version)
             for link_name, resource in self.linked_resources().items()
         }
-        if self.resource_url():
-            links_json["self"] = self.resource_url()
-        return links_json
 
     def as_linkage_json(self):
         return {"type": self.resource_type(), "id": self.resource_id_str()}
@@ -182,13 +179,13 @@ class JSONAPISerializer(object):
 
     def document_links_urls(self):
         links = {
+            "self": self.resource_url(),
             "next": self.next_page_url(),
             "prev": self.prev_page_url(),
             "last": self.last_page_url(),
             "first": self.first_page_url()
         }
-        links = {key: value for key, value in links.items() if value}
-        return links
+        return {key: value for key, value in links.items() if value}
 
     def included_resources_key(self, version):
         if version == JSONAPIVersion.JSONAPI_RC2:

--- a/test/test_jsonapi_serializer.py
+++ b/test/test_jsonapi_serializer.py
@@ -13,6 +13,11 @@ class ExampleSerializer(JSONAPISerializer):
     def resource_id(self):
         return str(self._id)
 
+    def resource_url(self):
+        return "http://www.example.com/examples/{}".format(
+            self.resource_id(),
+        )
+
     def attributes_dictionary(self):
         return {
             "title": "an example"
@@ -50,6 +55,9 @@ def test_api_resource():
             "attributes": {
                 "title": "an example"
             }
+        },
+        "links": {
+            "self": "http://www.example.com/examples/1",
         }
     }
     assert_equal(expected_json, resource.as_json_api_document())
@@ -66,7 +74,8 @@ def test_linked_resource():
             },
             "relationships": {
                 "something": {
-                    "data": {"type": "example", "id": "2"}
+                    "data": {"type": "example", "id": "2"},
+                    "related": "http://www.example.com/examples/2",
                 }
             }
         },
@@ -172,17 +181,23 @@ def test_linked_heterogeneous_collection():
                 "attributes": {
                     "title": "an example of linking"
                 },
-                "relationships": {"something": {"data": {"type": "example", "id": "3"}}}
+                "relationships": {
+                    "something": {
+                        "data": {"type": "example", "id": "3"},
+                        "related": "http://www.example.com/examples/3",
+                    },
+                },
             },
             {
                 "type": "example",
                 "id": "3",
                 "attributes": {
                     "title": "an example"
-                }
+                },
             },
         ]
     }
+    assert_equal.__self__.maxDiff = None
     assert_equal(expected_json, resource.as_json_api_document())
 
 
@@ -203,7 +218,12 @@ def test_toplevel_collection():
                 "attributes": {
                     "title": "an example of linking"
                 },
-                "relationships": {"something": {"data": {"type": "example", "id": "3"}}}
+                "relationships": {
+                    "something": {
+                        "data": {"type": "example", "id": "3"},
+                        "related": "http://www.example.com/examples/3",
+                    },
+                },
             },
         ],
         "included": [
@@ -251,7 +271,7 @@ def test_toplevel_collection_with_repeats():
                         {"type": "example", "id": "10"},
                         {"type": "linking_example", "id": "3"}
                     ]}
-                }
+                },
             },
         ],
         "included": [
@@ -262,8 +282,11 @@ def test_toplevel_collection_with_repeats():
                     "title": "an example of linking"
                 },
                 "relationships": {
-                    "something": {"data": {"type": "example", "id": "10"}}
-                }
+                    "something": {
+                        "data": {"type": "example", "id": "10"},
+                        "related": "http://www.example.com/examples/10",
+                    },
+                },
             },
         ]
     }


### PR DESCRIPTION
JSONAPI spec 1.0 specifies that `"self"` url should be in `"links"` instead of the current `"relationships"`. This change will not break rc2 or rc3 since it's additive as opposed to destructive.