### PR TITLE
Resource decorator for easier registraion of resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,7 @@ It has a class properties corresponding to the entries in the `resource_registry
 * `APIResource.MODEL_PRIME`, a method that can be passed an `id` which will improve the performance of future `MODEL_GET` calls
 
 To use this convenience class, you subclass it and either define those class properties
-and then call `MyAPIResourceSubclass.register_class()`
-or use e.g.
+and then use one of `MyAPIResourceSubclass.register_class()`, the `@resource` decorator or use e.g.
 ```python
 @MyAPIResourceSubclass.register(ResourceRegistryKeys.PARSER)
 class MySchemaParserSubclass(SchemaParser):

--- a/cartographer/resources/api_resource.py
+++ b/cartographer/resources/api_resource.py
@@ -6,6 +6,23 @@ from cartographer.schemas.schema import Schema
 from cartographer.serializers import SchemaSerializer
 
 
+def resource(cls):
+    """Can be used as decorator to specify a cartographer resource"""
+    registry = get_resource_registry_container()
+    registry.register_resource(
+        type_string=cls.type_string(),
+        schema=cls.SCHEMA,
+        serializer=cls.SERIALIZER,
+        parser=cls.PARSER,
+        mask=cls.MASK,
+        model=cls.MODEL,
+        model_get=cls.MODEL_GET,
+        model_prime=cls.MODEL_PRIME
+    )
+
+    return cls
+
+
 class APIResource(object):
     SCHEMA = Schema
     SERIALIZER = SchemaSerializer
@@ -45,14 +62,4 @@ class APIResource(object):
 
     @classmethod
     def register_class(cls):
-        registry = get_resource_registry_container()
-        registry.register_resource(
-            type_string=cls.type_string(),
-            schema=cls.SCHEMA,
-            serializer=cls.SERIALIZER,
-            parser=cls.PARSER,
-            mask=cls.MASK,
-            model=cls.MODEL,
-            model_get=cls.MODEL_GET,
-            model_prime=cls.MODEL_PRIME
-        )
+        resource(cls)


### PR DESCRIPTION
From my experience, the `.register_class()` approach becomes a mess really quickly. Since one ends with a single file initializing all the resources,
a copy-paste pattern appears that looks similar to:

```python
class MyResource(APIResource):
    SCHEMA = MySchema
    SERIALIZER = MySerializer
    PARSER = MyParser
    MASK = MyMask
    MODEL = My
    MODEL_GET = My.get

MyResource.register_class()
```

Because of this copy-paste fiasco, a lot of resources end up unregistered. This is a simple way to reduce code as well as combat copy-pasta.

Now the same above code will look like as:

```python
@resource
class MyResource(APIResource):
    SCHEMA = MySchema
    SERIALIZER = MySerializer
    PARSER = MyParser
    MASK = MyMask
    MODEL = My
    MODEL_GET = My.get
```