### PR TITLE
New SchemaAttribute descriptor notation for future validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ It is formatted to resemble the output structure of JSON API resources:
 ```python
 {
     "type": "widget",
-    "id": StringAttribute("widget_id"),
+    "id": StringAttribute()
+            .read_from(model_property="widget_id")
+            .self_explanatory(),
     "atributes": {
-        "price": IntAttribute("amount_cents")
+        "price": IntAttribute()
+            .read_from(model_property="amount_cents")
+            .description('The wiget price in cents'),
     },
     "relationships": {
         "distributing-store": SchemaRelationship(

--- a/cartographer/parsers/schema_parser.py
+++ b/cartographer/parsers/schema_parser.py
@@ -107,11 +107,9 @@ class SchemaParser(PostedDocument):
         :return: A tuple of the model property name and its corresponding parsed value
         """
         schema_attribute = self.schema().attribute(key)
-        if schema_attribute \
-                and schema_attribute.model_attribute \
-                and schema_attribute.is_property:
+        if schema_attribute and schema_attribute.model_property:
             serialized_value = self.data().attribute(key)
-            return schema_attribute.model_attribute, schema_attribute.from_json(serialized_value)
+            return schema_attribute.model_property, schema_attribute.from_json(serialized_value)
         # TODO: let SchemaAttribute declare parser_method
 
     def should_parse_attribute(self, key):

--- a/cartographer/schemas/schema.py
+++ b/cartographer/schemas/schema.py
@@ -8,9 +8,13 @@ class Schema(object):
     ```python
     {
         "type": "widget",
-        "id": StringAttribute("widget_id"),
+        "id": StringAttribute()
+                .read_from(model_property='widget_id')
+                .self_explanatory(),
         "atributes": {
-            "price": IntAttribute("amount_cents")
+            "price": IntAttribute()
+                .read_from(model_property='amount_cents')
+                .description('The price of the widget in cents'),
         },
         "relationships": {
             "manufacturer": SchemaRelationship(

--- a/example/generic_social_network/app/resources/follow_resource.py
+++ b/example/generic_social_network/app/resources/follow_resource.py
@@ -17,7 +17,9 @@ class FollowResource(APIResource):
 class FollowSchema(Schema):
     SCHEMA = {
         'type': 'follow',
-        'id': StringAttribute(serializer_method='follow_id'),
+        'id': StringAttribute()
+                .read_from(serializer_method='follow_id')
+                .self_explanatory(),
         'relationships': {
             'follower': SchemaRelationship(model_type='user', id_attribute='follower_id'),
             'followed': SchemaRelationship(model_type='user', id_attribute='followed_id')

--- a/example/generic_social_network/app/resources/post_resource.py
+++ b/example/generic_social_network/app/resources/post_resource.py
@@ -17,10 +17,16 @@ class PostResource(APIResource):
 class PostSchema(Schema):
     SCHEMA = {
         'type': 'post',
-        'id': StringAttribute('post_id'),
+        'id': StringAttribute()
+                .read_from(model_property='post_id')
+                .self_explanatory(),
         'attributes': {
-            'title': StringAttribute('title'),
-            'body': StringAttribute('body'),
+            'title': StringAttribute()
+                .read_from(model_property='title')
+                .description("The post's title text"),
+            'body': StringAttribute()
+                .read_from(model_property='body')
+                .description("The posts's content"),
         },
         'relationships': {
             'author': SchemaRelationship(model_type='user', id_attribute='author_id')

--- a/example/generic_social_network/app/resources/user_read_history_resource.py
+++ b/example/generic_social_network/app/resources/user_read_history_resource.py
@@ -17,9 +17,13 @@ class UserReadHistoryResource(APIResource):
 class UserReadHistorySchema(Schema):
     SCHEMA = {
         'type': 'user-read-history',
-        'id': StringAttribute(serializer_method='user_read_history_id'),
+        'id': StringAttribute()
+                .read_from(serializer_method='user_read_history_id')
+                .self_explanatory(),
         'attributes': {
-            'timestamp': DateAttribute('timestamp')
+            'timestamp': DateAttribute()
+                .read_from(model_property='timestamp')
+                .description('The time the user last read this post'),
         },
         'relationships': {
             'user': SchemaRelationship(model_type='user', id_attribute='user_id'),

--- a/example/generic_social_network/app/resources/user_resource.py
+++ b/example/generic_social_network/app/resources/user_resource.py
@@ -17,9 +17,13 @@ class UserResource(APIResource):
 class UserSchema(Schema):
     SCHEMA = {
         'type': 'user',
-        'id': StringAttribute('user_id'),
+        'id': StringAttribute()
+                .read_from(model_property='user_id')
+                .self_explanatory(),
         'attributes': {
-            'name': StringAttribute('name')
+            'name': StringAttribute()
+                .read_from(model_property='name')
+                .self_explanatory(),
         }
     }
 


### PR DESCRIPTION
This PR is a proposal of a way to move validation rules to the schema - away from endpoint implementations.

This opens the door to a lot of automation to eliminate programmer's time spent in crafting validation code outside of the schema - which is a source of truth for the resource.

It also allows us to add description (for documentation generation) and per-type specific validation. Each attribute type can have extra methods specific for it's type such as `range` for `IntAttribute` and `regex` for `StringAttribute` for future automatic validation.

It looks something like this (note that not all methods are implemented):
```python
class PledgeSchema(Schema):
    @staticmethod
    def get_attributes():
        return {
            'amount_cents': IntAttribute()
                .read_from(model_property='amount')
                .description('The amount of the pledge in cents')
                .unsigned(),
            'total_historical_amount_cents': IntAttribute()
                .read_from(serializer_method='total_historical_amount_cents')
                .description('The total amount given to the creator using this pledge')
                .computed(),
            'declined_since': DateAttribute()
                .read_from(model_property='invalidated_at')
                .description('If not null, the date and time of the first decline')
                .nullable()
                .computed(),
            'created_at': DateAttribute()
                .read_from(serializer_method='created_at')
                .self_explanatory()
                .computed(),
            'pledge_cap_cents': IntAttribute()
                .read_from(model_property='pledge_cap')
                .description('The total amount a month this pledge can reach. Only valid for per-post campaigns.')
                .unsigned()
                .nullable(),
            'patron_pays_fees': BoolAttribute('PatronPaysFees')
                .read_from(model_property='PatronPaysFees')
                .self_explanatory(),
            'unread_count': IntAttribute()
                .read_from(serializer_method='unread_count')
                .description('...')
                .computed(),
        }
```