### PR TITLE
Return 1 on tests failure

### DIFF
--- a/example/run_tests.py
+++ b/example/run_tests.py
@@ -10,4 +10,4 @@ controllers_test_suite = unittest.TestSuite([
     follows_controller_tests.suite,
     news_feed_controller_tests.suite
 ])
-runner.run(controllers_test_suite)
+exit(bool(runner.run(controllers_test_suite).errors))

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 source venv/bin/activate >/dev/null
 pip install -r requirements.txt >/dev/null


### PR DESCRIPTION
I've noticed that the `./run_tests.sh` script will always return success even though failures existed.
This fixes it.

This particularly affects CircleCI tests.