### PR TITLE
Don't parse computed attributes

### DIFF
--- a/cartographer/parsers/jsonapi_parser.py
+++ b/cartographer/parsers/jsonapi_parser.py
@@ -49,7 +49,7 @@ class PostedResource(object):
         return self.json_data.get("attributes", {})
 
     def attribute(self, name):
-        return self.attributes().get(name)
+        return self.attributes().get(name, None)
 
     def assert_type(self, resource_type, exception=Exception):
         if self.resource_type() != resource_type:

--- a/cartographer/parsers/schema_parser.py
+++ b/cartographer/parsers/schema_parser.py
@@ -113,7 +113,13 @@ class SchemaParser(PostedDocument):
         # TODO: let SchemaAttribute declare parser_method
 
     def should_parse_attribute(self, key):
-        return key in self.schema().attributes()
+        attribute = self.schema().attribute(key)
+        if not attribute:
+            return False
+        if attribute.is_computed:
+            return False
+
+        return True
 
     # Relationships
 


### PR DESCRIPTION
Attributes marked as `computed` should not be parsable. 