### PR TITLE
Force named argument usage in SchemaAttribute.read_from

### DIFF
--- a/cartographer/field_types/schema_attribute.py
+++ b/cartographer/field_types/schema_attribute.py
@@ -22,7 +22,7 @@ class SchemaAttribute(object):
         self.is_optional_on_create = False
         self.is_computed = False
 
-    def read_from(self, model_property=None, model_method=None, serializer_method=None):
+    def read_from(self, *, model_property=None, model_method=None, serializer_method=None):
         """
         Defines how to retrieve the value of the property. Only one parameter is allowed.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='cartographer',
-      version='0.2.0-alpha',
+      version='0.2.0-alpha2',
       description='Python library for using JSON API, especially with Flask.',
       url='http://github.com/Patreon/cartographer',
       author='Patreon',


### PR DESCRIPTION
We want to force named arguments when using `read_from` for readability. This allows us to do that.
The only drawback that I don't know how to solve well is that `read_from()` is still valid - but that is taken care of in `verify_configuration` (although not called yet)