### PR TITLE
Correct reference to literal 'key' string instead of the variable name.

### DIFF
--- a/cartographer/schemas/schema.py
+++ b/cartographer/schemas/schema.py
@@ -56,7 +56,7 @@ class Schema(object):
 
     @classmethod
     def attribute(cls, key):
-        return cls.attributes().get('key')
+        return cls.attributes().get(key)
 
     @classmethod
     def attributes(cls):


### PR DESCRIPTION
I don't know how this made it to production without breaking unit tests. I am marking this as "proposal" because I need to understand the implications of this and why it's not surfacing on production, as well as to write the corresponding unit tests. 

I also can't find the corresponding PR that merges these changes into `master`. It might just have been a long day, but there is definitely something strange going on.