### PR TITLE
Revert name change `Schema.type` back to `Schema.resource_type`

### DIFF
--- a/cartographer/schemas/schema.py
+++ b/cartographer/schemas/schema.py
@@ -47,7 +47,7 @@ class Schema(object):
     # Convenience methods for accessing pieces of the schema.
 
     @classmethod
-    def type(cls):
+    def resource_type(cls):
         return cls.schema().get('type')
 
     @classmethod


### PR DESCRIPTION
https://github.com/Patreon/cartographer/commit/cd1461cee39fb1e54473f759900b73c122c34685 broke tests by renaming `resource_type` to `type`. This restores the rename.