### PR TITLE
Fix a default arguments bug when instanciating a JSONAPICollectionSerializer

### DIFF
--- a/cartographer/serializers/jsonapi_collection_serializer.py
+++ b/cartographer/serializers/jsonapi_collection_serializer.py
@@ -8,8 +8,13 @@ class JSONAPICollectionSerializer(JSONAPISerializer):
     homogeneous_type = None
     links = {}
 
-    def __init__(self, members=[], links={}):
-        self._members = list(members) if members else members
+    def __init__(self, members=None, links=None):
+        if members is None:
+            members = []
+        if links is None:
+            links = {}
+
+        self._members = members
         self.links = links
 
     def members(self):


### PR DESCRIPTION
When using a list or dict as a function default value, they become a singleton and not instanciated on every call.
This causes problem mainly with links since `members` was already making a copy