### PR TITLE
Auto register resources via metaclass

### DIFF
--- a/example/generic_social_network/app/resources/follow_resource.py
+++ b/example/generic_social_network/app/resources/follow_resource.py
@@ -1,19 +1,11 @@
 from cartographer.field_types import StringAttribute, SchemaRelationship
 from cartographer.parsers.schema_parser import SchemaParser
 from cartographer.resources.api_resource import APIResource
-from cartographer.resources.resource_registry import ResourceRegistryKeys
 from cartographer.schemas.schema import Schema
 from cartographer.serializers import SchemaSerializer
 from generic_social_network.app.models.tables.follow import Follow
 
 
-class FollowResource(APIResource):
-    MODEL = Follow
-    MODEL_GET = Follow.get
-    # MODEL_PRIME = Follow.get.prime
-
-
-@FollowResource.register(ResourceRegistryKeys.SCHEMA)
 class FollowSchema(Schema):
     SCHEMA = {
         'type': 'follow',
@@ -27,7 +19,6 @@ class FollowSchema(Schema):
     }
 
 
-@FollowResource.register(ResourceRegistryKeys.SERIALIZER)
 class FollowSerializer(SchemaSerializer):
     @classmethod
     def schema(cls):
@@ -40,8 +31,17 @@ class FollowSerializer(SchemaSerializer):
         )
 
 
-@FollowResource.register(ResourceRegistryKeys.PARSER)
 class FollowParser(SchemaParser):
     @classmethod
     def schema(cls):
         return FollowSchema
+
+
+class FollowResource(APIResource):
+    SCHEMA = FollowSchema
+    SERIALIZER = FollowSerializer
+    PARSER = FollowParser
+    # MASK = BaseMask
+    MODEL = Follow
+    MODEL_GET = Follow.get
+    # MODEL_PRIME = Follow.get.prime

--- a/example/generic_social_network/app/resources/post_resource.py
+++ b/example/generic_social_network/app/resources/post_resource.py
@@ -1,19 +1,11 @@
 from cartographer.field_types import StringAttribute, SchemaRelationship, EnumAttribute
 from cartographer.parsers.schema_parser import SchemaParser
 from cartographer.resources.api_resource import APIResource
-from cartographer.resources.resource_registry import ResourceRegistryKeys
 from cartographer.schemas.schema import Schema
 from cartographer.serializers import SchemaSerializer
 from generic_social_network.app.models.tables.post import Post, PostType
 
 
-class PostResource(APIResource):
-    MODEL = Post
-    MODEL_GET = Post.get
-    # MODEL_PRIME = Post.get.prime
-
-
-@PostResource.register(ResourceRegistryKeys.SCHEMA)
 class PostSchema(Schema):
     SCHEMA = {
         'type': 'post',
@@ -37,14 +29,12 @@ class PostSchema(Schema):
     }
 
 
-@PostResource.register(ResourceRegistryKeys.SERIALIZER)
 class PostSerializer(SchemaSerializer):
     @classmethod
     def schema(cls):
         return PostSchema
 
 
-@PostResource.register(ResourceRegistryKeys.PARSER)
 class PostParser(SchemaParser):
     @classmethod
     def schema(cls):
@@ -56,3 +46,13 @@ class PostParser(SchemaParser):
             raise Exception("Provided post object was missing the author id field")
         if not inbound_data.attribute('body'):
             raise Exception("Provided post object was missing the body field")
+
+
+class PostResource(APIResource):
+    SCHEMA = PostSchema
+    SERIALIZER = PostSerializer
+    PARSER = PostParser
+    # MASK = BaseMask
+    MODEL = Post
+    MODEL_GET = Post.get
+    # MODEL_PRIME = Post.get.prime

--- a/example/generic_social_network/app/resources/user_read_history_resource.py
+++ b/example/generic_social_network/app/resources/user_read_history_resource.py
@@ -1,19 +1,11 @@
 from cartographer.field_types import StringAttribute, DateAttribute, SchemaRelationship
 from cartographer.parsers.schema_parser import SchemaParser
 from cartographer.resources.api_resource import APIResource
-from cartographer.resources.resource_registry import ResourceRegistryKeys
 from cartographer.schemas.schema import Schema
 from cartographer.serializers import SchemaSerializer
 from generic_social_network.app.models.tables.user_read_history import UserReadHistory
 
 
-class UserReadHistoryResource(APIResource):
-    MODEL = UserReadHistory
-    MODEL_GET = UserReadHistory.get
-    # MODEL_PRIME = UserReadHistory.get.prime
-
-
-@UserReadHistoryResource.register(ResourceRegistryKeys.SCHEMA)
 class UserReadHistorySchema(Schema):
     SCHEMA = {
         'type': 'user-read-history',
@@ -32,15 +24,23 @@ class UserReadHistorySchema(Schema):
     }
 
 
-@UserReadHistoryResource.register(ResourceRegistryKeys.SERIALIZER)
 class UserReadHistorySerializer(SchemaSerializer):
     @classmethod
     def schema(cls):
         return UserReadHistorySchema
 
 
-@UserReadHistoryResource.register(ResourceRegistryKeys.PARSER)
 class UserReadHistoryParser(SchemaParser):
     @classmethod
     def schema(cls):
         return UserReadHistorySchema
+
+
+class UserReadHistoryResource(APIResource):
+    SCHEMA = UserReadHistorySchema
+    SERIALIZER = UserReadHistorySerializer
+    PARSER = UserReadHistoryParser
+    # MASK = BaseMask
+    MODEL = UserReadHistory
+    MODEL_GET = UserReadHistory.get
+    # MODEL_PRIME = UserReadHistory.get.prime

--- a/example/generic_social_network/app/resources/user_resource.py
+++ b/example/generic_social_network/app/resources/user_resource.py
@@ -1,19 +1,11 @@
 from cartographer.field_types import StringAttribute
 from cartographer.parsers.schema_parser import SchemaParser
 from cartographer.resources.api_resource import APIResource
-from cartographer.resources.resource_registry import ResourceRegistryKeys
 from cartographer.schemas.schema import Schema
 from cartographer.serializers import SchemaSerializer
 from generic_social_network.app.models.tables.user import User
 
 
-class UserResource(APIResource):
-    MODEL = User
-    MODEL_GET = User.get
-    # MODEL_PRIME = User.get.prime
-
-
-@UserResource.register(ResourceRegistryKeys.SCHEMA)
 class UserSchema(Schema):
     SCHEMA = {
         'type': 'user',
@@ -28,14 +20,12 @@ class UserSchema(Schema):
     }
 
 
-@UserResource.register(ResourceRegistryKeys.SERIALIZER)
 class UserSerializer(SchemaSerializer):
     @classmethod
     def schema(cls):
         return UserSchema
 
 
-@UserResource.register(ResourceRegistryKeys.PARSER)
 class UserParser(SchemaParser):
     @classmethod
     def schema(cls):
@@ -45,3 +35,13 @@ class UserParser(SchemaParser):
         super().validate(inbound_data)
         if not inbound_data.attribute('name'):
             raise Exception("Provided user object was missing the name field")
+
+
+class UserResource(APIResource):
+    SCHEMA = UserSchema
+    SERIALIZER = UserSerializer
+    PARSER = UserParser
+    # MASK = BaseMask
+    MODEL = User
+    MODEL_GET = User.get
+    # MODEL_PRIME = User.get.prime


### PR DESCRIPTION
From my experience, the `.register_class()` approach becomes a mess really quickly. Since one ends with a single file initializing all the resources,
a copy-paste pattern appears that looks similar to:

```python
class MyResource(APIResource):
    SCHEMA = MySchema
    SERIALIZER = MySerializer
    PARSER = MyParser
    MASK = MyMask
    MODEL = My
    MODEL_GET = My.get

MyResource.register_class()
```

Because of this copy-paste fiasco, a lot of resources end up unregistered. This is a simple way to reduce code as well as combat copy-pasta.

Now the same above code will look like as:

```python
class MyResource(APIResource):
    SCHEMA = MySchema
    SERIALIZER = MySerializer
    PARSER = MyParser
    MASK = MyMask
    MODEL = My
    MODEL_GET = My.get
```