### PR TITLE
Handle `None` properly in nullable date attributes

### DIFF
--- a/cartographer/field_types/bool_attribute.py
+++ b/cartographer/field_types/bool_attribute.py
@@ -6,6 +6,5 @@ class BoolAttribute(SchemaAttribute):
     def format_value_for_json(cls, value):
         return bool(value)
 
-    @classmethod
-    def from_json(cls, serialized_value):
+    def from_json(self, serialized_value):
         return bool(str(serialized_value).lower() not in ['false', '0'])

--- a/cartographer/field_types/date_attribute.py
+++ b/cartographer/field_types/date_attribute.py
@@ -11,12 +11,15 @@ class DateAttribute(SchemaAttribute):
     def format_value_for_json(cls, value):
         return as_utc(value).isoformat()
 
-    @classmethod
-    def from_json(cls, serialized_value):
+    def from_json(self, serialized_value):
+        if self.is_nullable and serialized_value is None:
+            return None
+
         try:
             # ciso8601 is significantly faster than dateutil.parser for parsing iso8601 strings, so we try it first
             parsed_value = ciso8601.parse_datetime(serialized_value)
             assert parsed_value is not None  # Caveat: asserts won't run if python is run with -O.
         except Exception as e:
             parsed_value = dateutil.parser.parse(serialized_value)
+
         return make_naive(parsed_value)

--- a/cartographer/field_types/schema_attribute.py
+++ b/cartographer/field_types/schema_attribute.py
@@ -117,8 +117,7 @@ class SchemaAttribute(object):
         """
         return value
 
-    @classmethod
-    def from_json(cls, serialized_value):
+    def from_json(self, serialized_value):
         """
         :param serialized_value: The value to be parsed, as pulled directly from RequestInterface.get_json(force=True)
         :return: The parsed value, which can be dropped into a Python dictionary as the output of this Parser,

--- a/test/field_types/test_date_attribute.py
+++ b/test/field_types/test_date_attribute.py
@@ -1,0 +1,18 @@
+import nose.tools as t
+
+from cartographer.field_types.date_attribute import DateAttribute
+
+
+def test_not_nullable_date_field_errors_on_none():
+    attribute = DateAttribute().self_explanatory()
+
+    with t.assert_raises(AttributeError):
+        attribute.from_json(None)
+
+
+def test_nullable_date_field_can_parse_none():
+    attribute = DateAttribute().self_explanatory().nullable()
+
+    parsed_value = attribute.from_json(None)
+
+    t.assert_equals(parsed_value, None)


### PR DESCRIPTION
A date attribute should be nullable. Previously, the `from_json` would always try to parse the `None` value, which would cause an exception in both date-time parsing libraries. This updates the `from_json` to just return `None` if the attribute is defined to be nullable and the serialized value is `None`.

I had to un-class-method-ify the `from_json` because whether a date attribute is nullable or not depends on the value of an instance variable. I also un-class-method-ified the bool and schema attribute classes' `from_json` for consistency.