### PR TITLE
Update dependencies to support higher versions of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(name='cartographer',
       license='Apache 2.0',
       packages=find_packages(exclude=['example', 'example.*', 'test', 'test.*']),
       install_requires=[
-          'python-dateutil==2.4.2',
-          'ciso8601==1.0.1'
+          'python-dateutil>=2.4.2',
+          'ciso8601>=1.0.1'
       ],
       zip_safe=True,
       classifiers=[


### PR DESCRIPTION
Applications that use `cartographer` can get into dependency
hell if they try to upgrade pins on these libraries.