### PR TITLE
Bumped version of ciso8601

### DIFF
--- a/cartographer/field_types/date_attribute.py
+++ b/cartographer/field_types/date_attribute.py
@@ -18,7 +18,6 @@ class DateAttribute(SchemaAttribute):
         try:
             # ciso8601 is significantly faster than dateutil.parser for parsing iso8601 strings, so we try it first
             parsed_value = ciso8601.parse_datetime(serialized_value)
-            assert parsed_value is not None  # Caveat: asserts won't run if python is run with -O.
         except Exception as e:
             parsed_value = dateutil.parser.parse(serialized_value)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ciso8601==1.0.1
+ciso8601==2.0.1
 python-dateutil==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='cartographer',
       packages=find_packages(exclude=['example', 'example.*', 'test', 'test.*']),
       install_requires=[
           'python-dateutil>=2.4.2',
-          'ciso8601>=1.0.1'
+          'ciso8601>=2,<3'
       ],
       zip_safe=True,
       classifiers=[


### PR DESCRIPTION
As of version 2.0.0, ciso8601 now raises a `ValueError` instead of returning `None`.
It's also much much faster.

ciso8601 uses semantic versioning so it's safe to use '>=2,<3'

See https://github.com/closeio/ciso8601/blob/7855e3a084b9e09d5c0fc320c608d12bf848fb3a/CHANGELOG.md#v1xx---200-migration-guide for details